### PR TITLE
Delete Sin7Y zkEVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Table of Contents
 - [Hermez zkEVM](https://blog.hermez.io/introducing-hermez-zkevm/)
 - [Mir Protocol](https://mirprotocol.org/blog/Introducing-Mir)
 - [Scroll](https://hackmd.io/@yezhang/S1sJ2cEWY) and their [zkEVM](https://hackmd.io/@yezhang/S1_KMMbGt)
-- [Sin7Y zkEVM](https://medium.com/@sin7y)
 - [zCloak Space](https://zcloak.network/#/)
 - [Delphinus zkWASM](https://delphinuslab.com/zk-wasm/)
 - [Appliedzkp: Circuits for zkEVM](https://github.com/appliedzkp/zkevm-circuits)


### PR DESCRIPTION
Delete Sin7Y zkEVM since OlaVM (Sin7Y zkEVM) is added.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Solidity` in the description.
