### PR TITLE
Include Particle Network zkWaaS among wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ More specific to ZK:
 - [Zkopru: Affordable Ethereum Privacy Wallet](https://zkopru.network/)
 - [Bunkyr: zero‑knowledge security without seed phrases or backup codes](https://bunkyr.com/)
 - [Wasabi Wallet: non-custodial, privacy-focused Bitcoin wallet](https://wasabiwallet.io)
+- [Particle Network: Zero Knowledge Wallet-as-a-Service, confidential social logins and transactions](https://blog.particle.network/zkwaas-private-social-logins-and-transactions-dapps)
 
 #### Trustless Bridge
 


### PR DESCRIPTION
This PR adds Particle Network, a Wallet-as-a-Service provider who recently detailed native utilization of zkp's, to the wallets section.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Solidity` in the description.
