### PR TITLE
Add ZKLoRA Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ More specific to ZK:
 - [ZKML: Bridging AI/ML and Web3 with Zero-Knowledge Proofs](https://hackmd.io/@cathie/zkml)
 - [zkonduit: inference for deep learning models and other computational graphs in a zk-snark](https://github.com/zkonduit/ezkl)
 - [ZK Machine Learning: truly private machine learning, with zk-SNARKs and blockchain](https://github.com/zk-ml/demo)
+- [ZKLoRA: Efficient Zero-Knowledge Proofs for LoRA Verification](https://github.com/bagel-org/ZKLoRA)
 
 #### DeFi / DEX
 


### PR DESCRIPTION
This PR adds a link to the repository of ZKLoRA, a recent research that can be found [here](https://arxiv.org/abs/2501.13965).

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
