### PR TITLE
Add Midnight to Zk-Layer1:  privacy-enhancing blockchain with program…

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ More specific to ZK:
 - [Mir Protocol](https://mirprotocol.org/blog/Introducing-Mir)
 - [Aleo: A SDK for Zero-Knowledge Transactions](https://github.com/AleoHQ/aleo)
 - [Iron Fish: the universal privacy layer for crypto](https://ironfish.network/)
+- [Midnight: Privacy-enhancing blockchain with programmable and selective disclosure](https://midnight.network/)
 - [Mina: a payment system using a succinct blockchain](https://minaprotocol.com/wp-content/uploads/technicalWhitepaper.pdf)
 - [Celo: EVM compatible proof-of-stake layer-1](https://celo.org/) and their [Light clients with ZKPs](https://zeroknowledge.fm/93-2/)
 - [Zeeka Network: a light and scalable blockchain using ZKPs](https://hackmd.io/_Sw5u2lUR9GfBV5vwtoMSQ#Zeeka-Network---Whitepaper)


### PR DESCRIPTION
Adding Midnight to the Zk-Layer1 section under Projects. 

Midnight is a privacy-enhancing Layer 1 blockchain that launched mainnet on March 30th, 2026. It uses Halo2-based zero-knowledge proofs and a domain-specific contract language (Compact) to enable programmable selective disclosure, allowing developers to build applications that prove facts without revealing underlying data. Fits naturally alongside existing Zk-Layer1 entries such as Aleo, Iron Fish, and DarkFi, which share a privacy-focused Layer 1 profile.

Link to the project: https://midnight.network/

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Solidity` in the description.
